### PR TITLE
Issue #23 - Missing SetFailState

### DIFF
--- a/addons/sourcemod/scripting/soap_tf2dm.sp
+++ b/addons/sourcemod/scripting/soap_tf2dm.sp
@@ -272,6 +272,7 @@ public OnMapStart()
 			}
 		} while(KvGotoNextKey(g_hKv));
 	} else {
+		SetFailState("Map spawns missing. Map: %s", map);
 		LogError("File Not Found: %s", path);
 	}
 	// End spawn system.


### PR DESCRIPTION
If the map-config wasn't present it would not set the Plugin into a Failed State.