### PR TITLE
add cp_prolands_b2c

### DIFF
--- a/addons/sourcemod/configs/soap/cp_prolands_b2c.cfg
+++ b/addons/sourcemod/configs/soap/cp_prolands_b2c.cfg
@@ -1,0 +1,184 @@
+"Spawns"
+{
+	"red"
+	{
+		"RED under main bridge"
+		{       
+			"origin"	"475.37 -134.76 149.42"
+			"angles"	"0 -148.31 0"
+		}
+		"RED valley2"
+		{       
+			"origin"	"-685.92 1325.76 142.21"
+			"angles"	"0 -90 0"
+		}
+		"BLU valley2"
+		{       
+			"origin"	"674.10 -1338.06 143.71"
+			"angles"	"0 90 0"
+		}
+		"RED choke house"
+		{       
+			"origin"	"849.18 719.41 256.18"
+			"angles"	"0 -9.27 0"
+		}
+		"BLU under main bridge"
+		{       
+			"origin"	"475.37 -134.76 149.42"
+			"angles"	"0 -148.31 0"
+		}
+		
+		"BLU choke house"
+		{       
+			"origin"	"-847.22 -700.23 266.33"
+			"angles"	"0 171.43 0"
+		}
+		"RED under main bridge"
+		{       
+			"origin"	"-600.25 307.38 147.84"
+			"angles"	"3.96 14.83 0"
+		}
+		"BLU grass"
+		{       
+			"origin"	"-1080.18 -1097.93 61.37"
+			"angles"	"0 -175 0"
+		}
+		"RED grass"
+		{       
+			"origin"	"1093.90 1108.23 62.33"
+			"angles"	"0 3 0"
+		}
+		"BLU spire"
+		{       
+			"origin"	"-1685.79 -1733.04 258.33"
+			"angles"	"0 90 0"
+		}
+		"RED spire"
+		{       
+			"origin"	"1663.82 1711.34 261.94"
+			"angles"	"0 -97 0"
+		}
+		"RED little bridge"
+		{       
+			"origin"	"1261.80 1824.55 70"
+			"angles"	"0 -90 0"
+		}
+		"BLU behind spire"
+		{       
+			"origin"	"-2435.63 -1217.25 83.70"
+			"angles"	"0 0 0"
+		}
+		"RED behind spire"
+		{       
+			"origin"	"2408.02 1203.55 81.97"
+			"angles"	"0 179 0"
+		}
+		
+		"BLU little bridge"
+		{       
+			"origin"	"-1262.97 -1675.19 70"
+			"angles"	"0 0 0"
+		}
+		"RED outside 2nd resupply"
+		{       
+			"origin"	"80.47 1843.81 259.70"
+			"angles"	"0 0 0"
+		}
+		"BLU outside 2nd resupply"
+		{       
+			"origin"	"-83.98 -1834.97 260.02"
+			"angles"	"0 -179 0"
+		}
+	}
+	"blue"
+	{
+		"BLU under main bridge"
+		{       
+			"origin"	"475.37 -134.76 149.42"
+			"angles"	"0 -148.31 0"
+		}
+		"RED choke house"
+		{       
+			"origin"	"840.11 638.87 256.97"
+			"angles"	"0 0 0"
+		}
+		"BLU under main bridge"
+		{       
+			"origin"	"563.30 -327.24 137.22"
+			"angles"	"0 -180 0"
+		}
+		
+		"BLU choke house"
+		{       
+			"origin"	"-847.22 -595.39 256.97"
+			"angles"	"0 171.43 0"
+		}
+	
+		"RED under main bridge"
+		{       
+			"origin"	"-571.46 284.78 142.67"
+			"angles"	"0 0 0"
+		}
+		"BLU grass"
+		{       
+			"origin"	"-1102.62 -1210.18 66.28"
+			"angles"	"0 -175 0"
+		}
+		"RED grass"
+		{       
+			"origin"	"1101.18 1207.19 65.81"
+			"angles"	"0 3 0"
+		}
+		"BLU valley2"
+		{       
+			"origin"	"573.59 -1338.42 144.64"
+			"angles"	"0 90 0"
+		}
+		"RED valley2"
+		{       
+			"origin"	"-566.42 1327.88 142.86"
+			"angles"	"0 -90 0"
+		}
+		
+		"RED outside 2nd resupply"
+		{       
+			"origin"	"80.47 1939.59 256.97"
+			"angles"	"0 0 0"
+		}
+		"RED little bridge"
+		{       
+			"origin"	"1239.21 1645.58 70"
+			"angles"	"0 -179 0"
+		}
+		"RED behind spire"
+		{       
+			"origin"	"2472.12 1370.41 94.51"
+			"angles"	"0 179 0"
+		}
+		"RED spire"
+		{       
+			"origin"	"1661.05 1560.69 260.95"
+			"angles"	"0 -97 0"
+		}
+		"BLU little bridge"
+		{       
+			"origin"	"-1302.45 -1770.99 70"
+			"angles"	"0 90 0"
+		}
+		"BLU behind spire"
+		{       
+			"origin"	"-2490.67 -1410.10 97.98"
+			"angles"	"0 0 0"
+		}
+		"BLU spire"
+		{       
+			"origin"	"-1659.36 -1554.41 260.97"
+			"angles"	"0 90 0"
+		}
+		"BLU outside 2nd resupply"
+		{       
+			"origin"	"-84.24 -1945.65 256.98"
+			"angles"	"0 -179	 0"
+		}
+	}
+}


### PR DESCRIPTION
Simply copied from cp_badlands.

Might be useful to add a "map alias" system to handle the cases where a config can be used for multiple versions of a map